### PR TITLE
Support immutable models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "react-elmish",
       "version": "3.0.0",
       "license": "MIT",
+      "dependencies": {
+        "immer": "10.1.1"
+      },
       "devDependencies": {
         "@babel/cli": "7.26.4",
         "@babel/core": "7.26.7",
@@ -31,7 +34,7 @@
         "typescript": "5.7.3"
       },
       "peerDependencies": {
-        "react": ">=16.8.0 <19"
+        "react": ">=16.8.0 <20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7848,6 +7851,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "update": "npx -y npm-check-updates -i --install never && npx -y npm-check-updates -i --target minor --install never && npx -y npm-check-updates -i --target patch --install never && npm update",
     "semantic-release": "semantic-release"
   },
+  "dependencies": {
+    "immer": "10.1.1"
+  },
   "peerDependencies": {
     "react": ">=16.8.0 <20"
   },

--- a/src/ElmComponent.ts
+++ b/src/ElmComponent.ts
@@ -1,3 +1,4 @@
+import { castImmutable, freeze } from "immer";
 import React from "react";
 import { execCmd, logMessage, modelHasChanged } from "./Common";
 import { Services } from "./Init";
@@ -105,10 +106,15 @@ abstract class ElmComponent<TModel, TMessage extends Message, TProps> extends Re
 
 			logMessage(this.componentName, currentMessage);
 
-			const [defer, getDeferred] = createDefer<TModel, TMessage>();
-			const callBase = createCallBase(currentMessage, this.currentModel, this.props, { defer });
+			const immutableModel = castImmutable(freeze(this.currentModel, true));
 
-			const [model, ...commands] = this.update(this.currentModel, currentMessage, this.props, { defer, callBase });
+			const [defer, getDeferred] = createDefer<TModel, TMessage>();
+			const callBase = createCallBase(currentMessage, immutableModel, this.props, { defer });
+
+			const [model, ...commands] = this.update(immutableModel, currentMessage, this.props, {
+				defer,
+				callBase,
+			});
 
 			const [deferredModel, deferredCommands] = getDeferred();
 

--- a/src/Testing/getUpdateFn.ts
+++ b/src/Testing/getUpdateFn.ts
@@ -1,3 +1,4 @@
+import { castImmutable, freeze } from "immer";
 import type { Message, Nullable, UpdateFunctionOptions, UpdateMap, UpdateReturnType } from "../Types";
 import { createCallBase } from "../createCallBase";
 import { createDefer } from "../createDefer";
@@ -23,8 +24,10 @@ function getUpdateFn<TProps, TModel, TMessage extends Message>(
 	optionsTemplate?: Partial<UpdateFunctionOptions<TProps, TModel, TMessage>>,
 ) => UpdateReturnType<TModel, TMessage> {
 	return function updateFn(msg, model, props, optionsTemplate): UpdateReturnType<TModel, TMessage> {
+		const immutableModel = castImmutable(freeze(model, true));
+
 		const [defer, getDeferred] = createDefer<TModel, TMessage>();
-		const callBase = createCallBase(msg, model, props, { defer });
+		const callBase = createCallBase(msg, immutableModel, props, { defer });
 
 		const options: UpdateFunctionOptions<TProps, TModel, TMessage> = {
 			defer,
@@ -32,7 +35,7 @@ function getUpdateFn<TProps, TModel, TMessage extends Message>(
 			...optionsTemplate,
 		};
 
-		const [updatedModel, ...commands] = callUpdateMap(updateMap, msg, model, props, options);
+		const [updatedModel, ...commands] = callUpdateMap(updateMap, msg, immutableModel, props, options);
 
 		const [deferredModel, deferredCommands] = getDeferred();
 
@@ -59,8 +62,10 @@ function getUpdateAndExecCmdFn<TProps, TModel, TMessage extends Message>(
 	optionsTemplate?: Partial<UpdateFunctionOptions<TProps, TModel, TMessage>>,
 ) => Promise<[Partial<TModel>, Nullable<TMessage>[]]> {
 	return async function updateAndExecCmdFn(msg, model, props, optionsTemplate): Promise<[Partial<TModel>, Nullable<TMessage>[]]> {
+		const immutableModel = castImmutable(freeze(model, true));
+
 		const [defer, getDeferred] = createDefer<TModel, TMessage>();
-		const callBase = createCallBase(msg, model, props, { defer });
+		const callBase = createCallBase(msg, immutableModel, props, { defer });
 
 		const options: UpdateFunctionOptions<TProps, TModel, TMessage> = {
 			defer,
@@ -68,7 +73,7 @@ function getUpdateAndExecCmdFn<TProps, TModel, TMessage extends Message>(
 			...optionsTemplate,
 		};
 
-		const [updatedModel, ...commands] = callUpdateMap(updateMap, msg, model, props, options);
+		const [updatedModel, ...commands] = callUpdateMap(updateMap, msg, immutableModel, props, options);
 
 		const [deferredModel, deferredCommands] = getDeferred();
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,3 +1,5 @@
+import type { Immutable } from "immer";
+
 type Nullable<TType> = TType | null;
 
 interface Message {
@@ -40,7 +42,7 @@ type DeferFunction<TModel, TMessage> = (model: Partial<TModel>, ...commands: (Cm
 type CallBaseFunction<TModel, TProps, TMessage extends Message> = (
 	fn: (
 		msg: TMessage,
-		model: TModel,
+		model: Immutable<TModel>,
 		props: TProps,
 		// biome-ignore lint/suspicious/noExplicitAny: any is needed here to allow options of any type
 		...args: any[]
@@ -49,7 +51,7 @@ type CallBaseFunction<TModel, TProps, TMessage extends Message> = (
 
 type UpdateMapFunction<TProps, TModel, TMessage extends Message> = (
 	msg: TMessage,
-	model: TModel,
+	model: Immutable<TModel>,
 	props: TProps,
 	options: UpdateFunctionOptions<TProps, TModel, TMessage>,
 ) => UpdateReturnType<TModel, TMessage>;
@@ -60,7 +62,7 @@ interface UpdateFunctionOptions<TProps, TModel, TMessage extends Message, TSpeci
 }
 
 type UpdateFunction<TProps, TModel, TMessage extends Message> = (
-	model: TModel,
+	model: Immutable<TModel>,
 	msg: TMessage,
 	props: TProps,
 	options: UpdateFunctionOptions<TProps, TModel, TMessage>,
@@ -73,7 +75,7 @@ type UpdateFunction<TProps, TModel, TMessage extends Message> = (
 type UpdateMap<TProps, TModel, TMessage extends Message> = {
 	[TMessageName in TMessage["name"]]: (
 		msg: TMessage & { name: TMessageName },
-		model: TModel,
+		model: Immutable<TModel>,
 		props: TProps,
 		options: UpdateFunctionOptions<TProps, TModel, TMessage, TMessage & { name: TMessageName }>,
 	) => UpdateReturnType<TModel, TMessage>;

--- a/src/createCallBase.ts
+++ b/src/createCallBase.ts
@@ -1,8 +1,9 @@
+import type { Immutable } from "immer";
 import type { CallBaseFunction, Message, UpdateFunctionOptions, UpdateReturnType } from "./Types";
 
 function createCallBase<TProps, TModel, TMessage extends Message>(
 	msg: TMessage,
-	model: TModel,
+	model: Immutable<TModel>,
 	props: TProps,
 	options: Omit<UpdateFunctionOptions<TProps, TModel, TMessage>, "callBase">,
 ): CallBaseFunction<TModel, TProps, TMessage> {

--- a/src/useElmish.ts
+++ b/src/useElmish.ts
@@ -1,4 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
+import { castImmutable, freeze, type Immutable } from "immer";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { execCmd, logMessage, modelHasChanged } from "./Common";
 import { Services } from "./Init";
@@ -78,7 +79,7 @@ function useElmish<TProps, TModel, TMessage extends Message>({
 	init,
 	update,
 	subscription,
-}: UseElmishOptions<TProps, TModel, TMessage>): [TModel, Dispatch<TMessage>] {
+}: UseElmishOptions<TProps, TModel, TMessage>): [Immutable<TModel>, Dispatch<TMessage>] {
 	let running = false;
 	const buffer: TMessage[] = [];
 	let currentModel: Partial<TModel> = {};
@@ -198,7 +199,7 @@ function useElmish<TProps, TModel, TMessage extends Message>({
 		}
 	}, []);
 
-	return [initializedModel, dispatch];
+	return [castImmutable(freeze(initializedModel, true)), dispatch];
 
 	function handleMessage(nextMsg: TMessage): boolean {
 		if (!initializedModel) {
@@ -209,7 +210,7 @@ function useElmish<TProps, TModel, TMessage extends Message>({
 
 		logMessage(name, nextMsg);
 
-		const updatedModel = { ...initializedModel, ...currentModel };
+		const updatedModel = castImmutable(freeze({ ...initializedModel, ...currentModel }, true));
 
 		const [defer, getDeferred] = createDefer<TModel, TMessage>();
 		const callBase = createCallBase(nextMsg, updatedModel, propsRef.current, { defer });
@@ -233,7 +234,7 @@ function useElmish<TProps, TModel, TMessage extends Message>({
 function callUpdate<TProps, TModel, TMessage extends Message>(
 	update: UpdateFunction<TProps, TModel, TMessage> | UpdateMap<TProps, TModel, TMessage>,
 	msg: TMessage,
-	model: TModel,
+	model: Immutable<TModel>,
 	props: TProps,
 	options: UpdateFunctionOptions<TProps, TModel, TMessage>,
 ): UpdateReturnType<TModel, TMessage> {
@@ -247,7 +248,7 @@ function callUpdate<TProps, TModel, TMessage extends Message>(
 function callUpdateMap<TProps, TModel, TMessage extends Message>(
 	updateMap: UpdateMap<TProps, TModel, TMessage>,
 	msg: TMessage,
-	model: TModel,
+	model: Immutable<TModel>,
 	props: TProps,
 	options: UpdateFunctionOptions<TProps, TModel, TMessage>,
 ): UpdateReturnType<TModel, TMessage> {


### PR DESCRIPTION
Use "immer" to make the models returned by `useElmish` hook or passed to the update functions immutable.